### PR TITLE
Create unlisted streams for private Calendar events

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -50,6 +50,7 @@ def main():
     CALENDAR2YOUTUBE_CALENDAR_ID = os.getenv("CALENDAR2YOUTUBE_CALENDAR_ID", "")
     LIVE_STREAM_TITLE = os.getenv("LIVE_STREAM_TITLE", "")
     STREAMING_KEYWORDS = json.loads(os.getenv("STREAMING_KEYWORDS", '["[streaming]"]'))
+    PRIVATE_KEYWORDS = json.loads(os.getenv("PRIVATE_KEYWORDS", '["[private]"]'))
 
     if not CLASSROOM_CALENDAR_ID or not CALENDAR2YOUTUBE_CALENDAR_ID or not LIVE_STREAM_TITLE:
         logger.error("There is a missing configuration parameter")
@@ -58,7 +59,7 @@ def main():
     credentials = load_credentials()
     
     # Create handlers
-    g_cal_handler = GoogleCalendarHandler(credentials, CLASSROOM_CALENDAR_ID, CALENDAR2YOUTUBE_CALENDAR_ID, STREAMING_KEYWORDS)
+    g_cal_handler = GoogleCalendarHandler(credentials, CLASSROOM_CALENDAR_ID, CALENDAR2YOUTUBE_CALENDAR_ID, STREAMING_KEYWORDS, PRIVATE_KEYWORDS)
     youtube_handler = YouTubeHandler(credentials)
     youtube_handler.set_stream_title(LIVE_STREAM_TITLE)
 

--- a/src/youtube_handler.py
+++ b/src/youtube_handler.py
@@ -124,7 +124,7 @@ class YouTubeHandler(object):
                 logger.debug("Id: '{}' for stream '{}'".format(stream_id, title))
                 return stream_id
 
-    def create_broadcast(self, title, start_time, end_time):
+    def create_broadcast(self, title, start_time, end_time, privacy_status="public"):
         create_broadcast_response = self.service.liveBroadcasts().insert(
                                     part="snippet,status,contentDetails",
                                     body={
@@ -135,7 +135,7 @@ class YouTubeHandler(object):
                                         },
                                         "status": {
                                             "selfDeclaredMadeForKids": False,
-                                            "privacyStatus": "public"
+                                            "privacyStatus": privacy_status
                                             
                                         },
                                         "contentDetails": {

--- a/src/youtube_handler.py
+++ b/src/youtube_handler.py
@@ -83,8 +83,9 @@ class YouTubeHandler(object):
         title = calendar_event.title
         start = calendar_event.start_date
         end = calendar_event.end_date
+        privacy_status = "unlisted" if calendar_event.is_private() else "public"
 
-        broadcast_id = self.create_broadcast(title, start, end)
+        broadcast_id = self.create_broadcast(title, start, end, privacy_status)
         self.bind_broadcast(broadcast_id, self.stream_id)
 
     def delete_youtube_event(self, youtube_event):


### PR DESCRIPTION
If certain keywords are present in the event description ("[private]" by default), the YouTube streaming will be created as unlisted.

Closes #1 

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>